### PR TITLE
netlify 설정

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/"
+  status = 200


### PR DESCRIPTION
closes #34
페이지에 대한 모든 요청을 baseUrl로 redirect 시켜 404에러가 발생하지 않도록 수정했습니다.