### PR TITLE
[예약] 데스크톱 UI 확장

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,6 +22,8 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+    <link href='//spoqa.github.io/spoqa-han-sans/css/SpoqaHanSansNeo.css' rel='stylesheet' type='text/css'>
+    <link href='//spoqa.github.io/spoqa-han-sans/css/SpoqaHanSans-jp.css' rel='stylesheet' type='text/css'>
     <title>WeTicket</title>
   </head>
   <body>

--- a/src/assets/styles/global-styles.ts
+++ b/src/assets/styles/global-styles.ts
@@ -1,4 +1,3 @@
-
 import { createGlobalStyle } from 'styled-components';
 import { normalize } from 'styled-normalize';
 
@@ -50,9 +49,7 @@ export const GlobalStyle = createGlobalStyle`
   }
 
   * {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    font-family: 'Spoqa Han Sans Neo', 'Spoqa Han Sans JP', sans-serif !important;
   }
+
 `;
-
-
- 

--- a/src/pages/Reservation/ReservationPresenter.tsx
+++ b/src/pages/Reservation/ReservationPresenter.tsx
@@ -293,7 +293,10 @@ export const ReservationPresenter: React.FC<ReservationPresenterProps> = ({
         <SelectedSeats>
           {selectedSeats.length > 0 ? selectedSeats.join(', ') : '없음'}
         </SelectedSeats>
-        <Submit disabled={loading} onClick={onSubmit}>
+        <Submit
+          disabled={selectedSeats.length === 0 || loading}
+          onClick={onSubmit}
+        >
           예약
         </Submit>
       </Content>

--- a/src/pages/Reservation/ReservationPresenter.tsx
+++ b/src/pages/Reservation/ReservationPresenter.tsx
@@ -236,6 +236,7 @@ export const ReservationPresenter: React.FC<ReservationPresenterProps> = ({
             <option value={timeOption}>{timeOption}</option>
           ))}
         </select>
+
         <InputHeader>좌석선택</InputHeader>
         {seatLayout && !reservationsLoading ? (
           <SeatWrapper>
@@ -245,12 +246,17 @@ export const ReservationPresenter: React.FC<ReservationPresenterProps> = ({
                   ? seatLayout.map.size.width
                   : Math.min(windowSize.width, 425)
               }
-              height={300}
+              height={
+                windowSize.width >= 1100 ? seatLayout.map.size.height : 300
+              }
               options={{
                 backgroundColor: getHexNumber(seatLayout.map.background),
               }}
               style={{
-                marginLeft: -(Math.min(windowSize.width, 425) - 320) / 2,
+                marginLeft:
+                  windowSize.width >= 1100
+                    ? 0
+                    : -(Math.min(windowSize.width, 425) - 320) / 2,
               }}
             >
               <Viewport
@@ -258,7 +264,9 @@ export const ReservationPresenter: React.FC<ReservationPresenterProps> = ({
                   windowSize.width,
                   seatLayout.map.size.width,
                 )}
-                viewportHeight={300}
+                viewportHeight={
+                  windowSize.width >= 1100 ? seatLayout.map.size.height : 300
+                }
                 worldWidth={seatLayout.map.size.width}
                 worldHeight={seatLayout.map.size.height}
               >
@@ -293,12 +301,14 @@ export const ReservationPresenter: React.FC<ReservationPresenterProps> = ({
         <SelectedSeats>
           {selectedSeats.length > 0 ? selectedSeats.join(', ') : '없음'}
         </SelectedSeats>
-        <Submit
-          disabled={selectedSeats.length === 0 || loading}
-          onClick={onSubmit}
-        >
-          예약
-        </Submit>
+        <Buttons>
+          <Submit
+            disabled={selectedSeats.length === 0 || loading}
+            onClick={onSubmit}
+          >
+            예약
+          </Submit>
+        </Buttons>
       </Content>
     </Container>
   );
@@ -308,6 +318,13 @@ const Container = styled.div`
   flex: 1;
   margin-top: 40px;
   background-color: ${colors.white};
+  @media (min-width: 1100px) {
+    height: calc(100vh - 80px);
+    margin-top: 80px;
+    padding-top: 40px;
+    background-color: ${colors.primary};
+    box-sizing: border-box;
+  }
 `;
 
 const Content = styled.div`
@@ -316,6 +333,12 @@ const Content = styled.div`
   padding: 10px;
   box-sizing: border-box;
   flex-direction: column;
+  @media (min-width: 1100px) {
+    width: 1100px;
+    border-radius: 12px;
+    background-color: ${colors.white};
+    padding: 40px;
+  }
 `;
 
 const InputHeader = styled.p<{ first?: boolean }>`
@@ -334,12 +357,23 @@ const Loader = styled.div`
 
 const SeatWrapper = styled.div`
   margin: 0 -10px;
+  @media (min-width: 1100px) {
+    display: flex;
+    justify-content: center;
+    padding: 20px 0;
+  }
 `;
 
 const SelectedSeats = styled.p`
   font-size: 15px;
   line-height: 1.6;
   font-weight: 400;
+`;
+
+const Buttons = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-top: 20px;
 `;
 
 const Submit = styled.button`
@@ -352,7 +386,10 @@ const Submit = styled.button`
   line-height: 1.6;
   font-weight: bold;
   border: none;
-  margin-top: 20px;
+
+  @media (min-width: 1100px) {
+    width: 270px;
+  }
 
   &:disabled {
     background-color: ${colors.gray};

--- a/src/pages/Reservation/ReservationPresenter.tsx
+++ b/src/pages/Reservation/ReservationPresenter.tsx
@@ -223,78 +223,96 @@ export const ReservationPresenter: React.FC<ReservationPresenterProps> = ({
 
   return (
     <Container>
-      <InputHeader first>날짜</InputHeader>
-      <DatePicker
-        selected={date}
-        onChange={onChangeDate}
-        minDate={tommorrow()}
-      />
-      <InputHeader>시간</InputHeader>
-      <select value={time} onChange={e => setTime(e.target.value)}>
-        {timeOptions.map(timeOption => (
-          <option value={timeOption}>{timeOption}</option>
-        ))}
-      </select>
-      <InputHeader>좌석선택</InputHeader>
-      {seatLayout && !reservationsLoading ? (
-        <SeatWrapper>
-          <Stage
-            width={Math.min(windowSize.width, seatLayout.map.size.width)}
-            height={300}
-            options={{
-              backgroundColor: getHexNumber(seatLayout.map.background),
-            }}
-          >
-            <Viewport
-              viewportWidth={Math.min(
-                windowSize.width,
-                seatLayout.map.size.width,
-              )}
-              viewportHeight={300}
-              worldWidth={seatLayout.map.size.width}
-              worldHeight={seatLayout.map.size.height}
+      <Content>
+        <InputHeader first>날짜</InputHeader>
+        <DatePicker
+          selected={date}
+          onChange={onChangeDate}
+          minDate={tommorrow()}
+        />
+        <InputHeader>시간</InputHeader>
+        <select value={time} onChange={e => setTime(e.target.value)}>
+          {timeOptions.map(timeOption => (
+            <option value={timeOption}>{timeOption}</option>
+          ))}
+        </select>
+        <InputHeader>좌석선택</InputHeader>
+        {seatLayout && !reservationsLoading ? (
+          <SeatWrapper>
+            <Stage
+              width={
+                windowSize.width >= 1100
+                  ? seatLayout.map.size.width
+                  : Math.min(windowSize.width, 425)
+              }
+              height={300}
+              options={{
+                backgroundColor: getHexNumber(seatLayout.map.background),
+              }}
+              style={{
+                marginLeft: -(Math.min(windowSize.width, 425) - 320) / 2,
+              }}
             >
-              {seatLayout.seats.map((seat, seatIndex) => {
-                const rectangleColor = getHexNumber(seat.color);
-                return seat.rectangles.map((rectangle, rectangleIndex) => {
-                  const seatId = `${seatCategory[seatIndex]}${rectangleIndex}`;
+              <Viewport
+                viewportWidth={Math.min(
+                  windowSize.width,
+                  seatLayout.map.size.width,
+                )}
+                viewportHeight={300}
+                worldWidth={seatLayout.map.size.width}
+                worldHeight={seatLayout.map.size.height}
+              >
+                {seatLayout.seats.map((seat, seatIndex) => {
+                  const rectangleColor = getHexNumber(seat.color);
+                  return seat.rectangles.map((rectangle, rectangleIndex) => {
+                    const seatId = `${seatCategory[seatIndex]}${rectangleIndex}`;
 
-                  return (
-                    <Rectangle
-                      key={`seat_${seatIndex}_${rectangleIndex}`}
-                      color={rectangleColor}
-                      {...rectangle}
-                      selected={selectedSeats.includes(seatId)}
-                      disabled={reservedSeats.includes(seatId)}
-                      onClick={() => {
-                        onSelectSeat(seatId);
-                      }}
-                    />
-                  );
-                });
-              })}
-            </Viewport>
-          </Stage>
-        </SeatWrapper>
-      ) : (
-        <Loader>
-          <Spinner />
-        </Loader>
-      )}
-      <InputHeader>선택 좌석</InputHeader>
-      <SelectedSeats>{selectedSeats.join(', ')}</SelectedSeats>
-      <Submit disabled={loading} onClick={onSubmit}>
-        예약
-      </Submit>
+                    return (
+                      <Rectangle
+                        key={`seat_${seatIndex}_${rectangleIndex}`}
+                        color={rectangleColor}
+                        {...rectangle}
+                        selected={selectedSeats.includes(seatId)}
+                        disabled={reservedSeats.includes(seatId)}
+                        onClick={() => {
+                          onSelectSeat(seatId);
+                        }}
+                      />
+                    );
+                  });
+                })}
+              </Viewport>
+            </Stage>
+          </SeatWrapper>
+        ) : (
+          <Loader>
+            <Spinner />
+          </Loader>
+        )}
+        <InputHeader>선택 좌석</InputHeader>
+        <SelectedSeats>
+          {selectedSeats.length > 0 ? selectedSeats.join(', ') : '없음'}
+        </SelectedSeats>
+        <Submit disabled={loading} onClick={onSubmit}>
+          예약
+        </Submit>
+      </Content>
     </Container>
   );
 };
 
 const Container = styled.div`
   flex: 1;
-  flex-direction: column;
-  padding: 10px;
   margin-top: 40px;
+  background-color: ${colors.white};
+`;
+
+const Content = styled.div`
+  width: 320px;
+  margin: 0 auto;
+  padding: 10px;
+  box-sizing: border-box;
+  flex-direction: column;
 `;
 
 const InputHeader = styled.p<{ first?: boolean }>`
@@ -331,7 +349,7 @@ const Submit = styled.button`
   line-height: 1.6;
   font-weight: bold;
   border: none;
-  margin-top: 100px;
+  margin-top: 20px;
 
   &:disabled {
     background-color: ${colors.gray};

--- a/src/routes/LoggedInRoutes/LoggedInHeader.tsx
+++ b/src/routes/LoggedInRoutes/LoggedInHeader.tsx
@@ -20,23 +20,22 @@ export const LoggedInHeader: React.FC = () => {
 
   return (
     <Container>
-      <Logo to="/reservation">WeTicket</Logo>
-      <Tickets
-        alt="reservations"
-        src={ticketIcon}
-        onClick={moveToReservations}
-      />
-      <Logout onClick={logout}>로그아웃</Logout>
+      <Content>
+        <Logo to="/reservation">WeTicket</Logo>
+        <Tickets
+          alt="reservations"
+          src={ticketIcon}
+          onClick={moveToReservations}
+        />
+        <Logout onClick={logout}>로그아웃</Logout>
+      </Content>
     </Container>
   );
 };
 
 const Container = styled.div`
   width: 100%;
-  height: 40px;
-  display: flex;
-  align-items: center;
-  padding: 0 10px;
+
   background-color: ${colors.primary};
   position: fixed;
   top: 0;
@@ -45,18 +44,36 @@ const Container = styled.div`
   z-index: 1;
 `;
 
+const Content = styled.div`
+  display: flex;
+  height: 40px;
+  align-items: center;
+  padding: 0 10px;
+  @media (min-width: 1100px) {
+    width: 1100px;
+    height: 80px;
+    margin: 0 auto;
+  }
+`;
+
 const Logo = styled(Link)`
   font-size: 18px;
-  line-height: 21px;
+  line-height: 1.6;
   color: ${colors.white};
   font-weight: bold;
   text-decoration: none;
+  @media (min-width: 1100px) {
+    font-size: 32px;
+  }
 `;
 
 const Tickets = styled.img`
   height: 18px;
   margin-left: auto;
   cursor: pointer;
+  @media (min-width: 1100px) {
+    height: 30px;
+  }
 `;
 
 const Logout = styled.button`
@@ -65,8 +82,14 @@ const Logout = styled.button`
   background-color: ${colors.white};
   color: ${colors.primary};
   font-size: 6px;
-  line-height: 10px;
+  line-height: 1.6;
   font-weight: bold;
   border: none;
   margin-left: 10px;
+
+  @media (min-width: 1100px) {
+    font-size: 18px;
+    padding: 10px 20px;
+    margin-left: 25px;
+  }
 `;


### PR DESCRIPTION
closes #16 

### 스크린샷
![스크린샷 2021-12-01 오전 3 12 20](https://user-images.githubusercontent.com/43431790/144103969-54b79a00-1841-4244-858e-7fe31fa25cbd.png)

### 추가 변경점
- 로그인 라우터의 헤더 UI 확장
- 글로벌 폰트 적용 : Spoqa Han Sans Neo