### PR TITLE
[예약목록] 예약목록이 rendering 될 때마다 refetch, refetch 될 때마다 loading = true

### DIFF
--- a/src/pages/Reservations/ReservationsPresenter.tsx
+++ b/src/pages/Reservations/ReservationsPresenter.tsx
@@ -31,7 +31,7 @@ export const ReservationsPresenter: React.FC<ReservationPresenterProps> = ({
   cancelReservation,
   reserveSeat,
 }) => {
-  const { data, loading } = useMeQuery();
+  const { data, loading, refetch } = useMeQuery({ notifyOnNetworkStatusChange : true });
   const [clicked, setClicked] = useState('');
   const [modal, setModal] = useState({isOpen:false, isCancel:false});
   const [reservations, setReservations] = useState(data?.me.reservations || []);
@@ -43,6 +43,10 @@ export const ReservationsPresenter: React.FC<ReservationPresenterProps> = ({
   const reserved = reservations.filter(
     reservation => reservation.status === ReservationStatus.Reserved,
   );
+  
+  useEffect(()=>{
+    refetch()
+  },[])
 
   useEffect(() => {
     setReservations(reservations => data?.me.reservations || []);


### PR DESCRIPTION
closes #46

이제 예약목록이 렌더링 될 때마다 refetch합니다.

refetch될 때 로딩이 필요하다고 생각해 client의 query 옵션에
notifyOnNetworkStatusChange: true를 추가하였습니다.

apollographql/react-apollo#321
https://stackoverflow.com/questions/55341558/refetching-a-query-with-react-apollo-why-is-loading-not-true/55373140
를 참고하였습니다