### PR TITLE
[예약 목록] 데스크톱 UI 수정

### DIFF
--- a/src/pages/Reservations/ReservationsPresenter.tsx
+++ b/src/pages/Reservations/ReservationsPresenter.tsx
@@ -172,7 +172,7 @@ export const ReservationsPresenter: React.FC<ReservationPresenterProps> = ({
     return result;
   };
 
-  const loadingScreen = <Spinner />;
+  const loadingScreen = <SContainer><Loader><Spinner /></Loader></SContainer>;
 
   const LoadedScreen = (
       <SContainer>
@@ -320,12 +320,15 @@ const SContainer = styled.div`
   padding-top: 8px;
   align-items: center;
   z-index: -1;
+  box-sizing: border-box;
+  min-height: calc(100vh - 20px);
   @media (min-width: 1100px) {
     width: 1100px;
     border-radius: 12px;  
     background-color: ${colors.white};
-    box-sizing: border-box;
     row-gap: 20px;
+    min-height: 0;
+    margin: auto;
     margin-bottom: 40px;
   }
 `;
@@ -336,10 +339,11 @@ const BackgroundBlur = styled.div<{isVisible:boolean}>`
     z-index: 0;
     @media (min-width: 1100px) {
       padding-top:80px;
+      display: box;
+      min-height: 100%;
       background-color: ${colors.primary};
       box-sizing: border-box;
       justify-content: center;
-      display:flex;
     }
     ${props=>props.isVisible&&`backdrop-filter: blur(8px);opacity:0.2;pointer-events:none;  position:fixed; top:-${window.scrollY}px;`}
 `;
@@ -368,7 +372,11 @@ const ModalLid = styled.div`
     height: 100px;
   }
 `
-
+const Loader = styled.div`
+  position: relative;
+  width: 100%;
+  height: 300px;
+`
 const ModalBottom = styled.div`
   position:fixed;
   box-sizing: border-box;


### PR DESCRIPTION
closes #47 

![image](https://user-images.githubusercontent.com/44893094/144725304-391dc48f-15e8-49fe-90f6-634daed9943e.png)
예약 목록이 짧아도 배경이 채워지도록 min-height를 설정하였습니다.

![image](https://user-images.githubusercontent.com/44893094/144725330-ade9e967-cb45-4bf4-8ae0-1167f44f51bd.png)
누락되었던 로딩 스피너를 추가하였습니다.